### PR TITLE
use hostname of device to advertise bluetooth

### DIFF
--- a/lib/bluetooth-service.js
+++ b/lib/bluetooth-service.js
@@ -15,7 +15,7 @@ bluetoothService.initialize = () => {
 bluetoothService.startAdvertising = () => {
     if (active && bleno.state === 'poweredOn') {
         bleno.startAdvertising(
-            'BoT Connected device',
+            os.hostname(),
             [blenoService.uuid]
         );
     }


### PR DESCRIPTION
We advertise with the hostname so when there are multiple devices (e.g. in a meetup) that we can easily identify which one we have to pair with.