### PR TITLE
Delete the configuration files

### DIFF
--- a/lib/configuration-service.js
+++ b/lib/configuration-service.js
@@ -28,7 +28,7 @@ configurationService.initialize = () => {
 };
 
 configurationService.removeConfiguration = () => {
-    Store.setMakerID('');
+    Store.reset();
 };
 
 configurationService.resumeConfiguration = () => {

--- a/lib/store.js
+++ b/lib/store.js
@@ -2,9 +2,14 @@ const Logger = require('./logger');
 
 const Storage = require('node-storage');
 
-const actionStorage = new Storage('./storage/actions.json');
-const configurationStorage = new Storage('./storage/configuration.json');
-const lastTriggeredStorage = new Storage('./storage/last-triggered.json');
+const actionsPath = './storage/actions.json';
+const configurationPath = './storage/configuration.json';
+const lastTriggeredPath = './storage/last-triggered.json';
+const QRCodePath = './storage/qr.png';
+
+const actionStorage = new Storage(actionsPath);
+const configurationStorage = new Storage(configurationPath);
+const lastTriggeredStorage = new Storage(lastTriggeredPath);
 
 const fileSystem = require('fs');
 const QRCode = require('qrcode');
@@ -86,12 +91,30 @@ store.setLastTriggeredAt = (actionID, date) => {
 };
 
 store.saveQRCode = (data) => {
-    QRCode.toFile('./storage/qr.png', data, (error) => {
+    QRCode.toFile(QRCodePath, data, (error) => {
         if (error) {
             logger.error('Store: Could not save QR Code. Error: ', error);
         }
     });
 };
+
+store.reset = () => {
+	if (fileSystem.existsSync(actionsPath)) {
+	fileSystem.unlinkSync(actionsPath)
+	}	
+	
+	if (fileSystem.existsSync(configurationPath)) {
+	fileSystem.unlinkSync(configurationPath)
+	}	
+	
+	if (fileSystem.existsSync(lastTriggeredPath)) {
+	fileSystem.unlinkSync(lastTriggeredPath)
+	}	
+	
+	if (fileSystem.existsSync(QRCodePath)) {
+	fileSystem.unlinkSync(QRCodePath)
+	}	
+}
 
 function setValueForKey (key, value) {
     value === ''

--- a/lib/store.js
+++ b/lib/store.js
@@ -99,21 +99,21 @@ store.saveQRCode = (data) => {
 };
 
 store.reset = () => {
-	if (fileSystem.existsSync(actionsPath)) {
-	fileSystem.unlinkSync(actionsPath)
-	}	
-	
-	if (fileSystem.existsSync(configurationPath)) {
-	fileSystem.unlinkSync(configurationPath)
-	}	
-	
-	if (fileSystem.existsSync(lastTriggeredPath)) {
-	fileSystem.unlinkSync(lastTriggeredPath)
-	}	
-	
-	if (fileSystem.existsSync(QRCodePath)) {
-	fileSystem.unlinkSync(QRCodePath)
-	}	
+    if (fileSystem.existsSync(actionsPath)) {
+        fileSystem.unlinkSync(actionsPath)
+    }	
+
+    if (fileSystem.existsSync(configurationPath)) {
+        fileSystem.unlinkSync(configurationPath)
+    }	
+
+    if (fileSystem.existsSync(lastTriggeredPath)) {
+        fileSystem.unlinkSync(lastTriggeredPath)
+    }	
+
+    if (fileSystem.existsSync(QRCodePath)) {
+        fileSystem.unlinkSync(QRCodePath)
+    }	
 }
 
 function setValueForKey (key, value) {

--- a/lib/store.js
+++ b/lib/store.js
@@ -99,31 +99,26 @@ store.saveQRCode = (data) => {
 };
 
 store.reset = () => {
-    if (fileSystem.existsSync(actionsPath)) {
-        fileSystem.unlinkSync(actionsPath)
-    }	
+    resetFile(actionsPath);
+    resetFile(configurationPath);
+    resetFile(lastTriggeredPath);
+    resetFile(QRCodePath);
+};
 
-    if (fileSystem.existsSync(configurationPath)) {
-        fileSystem.unlinkSync(configurationPath)
-    }	
-
-    if (fileSystem.existsSync(lastTriggeredPath)) {
-        fileSystem.unlinkSync(lastTriggeredPath)
-    }	
-
-    if (fileSystem.existsSync(QRCodePath)) {
-        fileSystem.unlinkSync(QRCodePath)
-    }	
+function resetFile(path) {
+    if (fileSystem.existsSync(path)) {
+        fileSystem.unlinkSync(path)
+    }
 }
 
-function setValueForKey (key, value) {
+function setValueForKey(key, value) {
     value === ''
         ? configurationStorage.remove(key)
         : configurationStorage.put(key, value);
 }
 
 // Defaults to undefined if key is not found
-function getValueForKey (key) {
+function getValueForKey(key) {
     return configurationStorage.get(key);
 }
 


### PR DESCRIPTION
Delete the the files in Storage that holds the current configuration.
It can be confusing that you reset the SDK `make reset` and the QRCode is still there for a non-existing device.

Signed-off-by: Pim Stolk <pim@bankingofthings.io>